### PR TITLE
Ensure ink globals persist to Redux state

### DIFF
--- a/src/state/actions.js
+++ b/src/state/actions.js
@@ -32,8 +32,9 @@ export const makeChoice = choiceIdx => {
   }
 };
 
+const sceneText = [];
+
 export const gameLoop = () => {
-  const sceneText = [];
   let currentTags = [];
 
   while (ink.canContinue) {
@@ -56,10 +57,10 @@ export const gameLoop = () => {
 };
 
 export const getGlobalVars = variablesState =>
-  Object.keys(variablesState._globalVariables).reduce(
-    (acc, key) => ({
+  Array.from(variablesState._globalVariables).reduce(
+    (acc, [key, entry]) => ({
       ...acc,
-      [key]: variablesState[key]
+      [key]: entry.value
     }),
     {}
   );


### PR DESCRIPTION
Previously it was trying to use Object.keys() on the underlying Map which just returns an empty array. This converts the map to an Array before attempting to reduce it allowing the variables to be persisisted to Redux..